### PR TITLE
If running on CircleCI, ensure gems are cached by using vendor folder

### DIFF
--- a/template/bin/setup
+++ b/template/bin/setup
@@ -7,9 +7,14 @@
 set -e
 
 # Set up Ruby dependencies via Bundler.
-gem install bundler --conservative
-bundle check || bundle install
-bundle update
+# If running on CircleCI, ensure gems are cached by using vendor folder.
+if [ -z "$CIRCLECI" ]; then
+  gem install bundler --conservative
+  bundle check || bundle install
+  bundle update
+else
+  bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 
+fi
 
 # Set up JS dependencies via Bower.
 bower --version > /dev/null || npm install -g bower


### PR DESCRIPTION
eg. reduced build time of one project from 2 minutes 36 seconds down to 56 seconds
