### PR TITLE
robots.txt to exclude all search engines by default

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Given the nature of the prototype sites jalpha is used for, IMHO we should, by default, prevent jalpha prototypes from having their content indexed by search engines.
